### PR TITLE
change: require `MUJOCO_DIR` instead of `MUJOCO_LIB`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
           rustup default ${{ matrix.toolchain }}
           rustup component add rustfmt  ### required for the build script to work ###
 
-      - name: check fails without MUJOCO_LIB
+      - name: check fails without MUJOCO_DIR
         run: |
           if cargo build; then
             echo 'cargo check succeeded without mujoco, which is unexpected.'
@@ -30,16 +30,16 @@ jobs:
             echo 'cargo check failed as expected without mujoco.'
           fi
           
-      - name: install mujoco and set MUJOCO_LIB
+      - name: install mujoco and set MUJOCO_DIR
         run: |
           mkdir -p $HOME/.mujoco
           cd $HOME/.mujoco
           wget https://github.com/google-deepmind/mujoco/releases/download/3.3.2/mujoco-3.3.2-linux-x86_64.tar.gz
           tar -xzf mujoco-3.3.2-linux-x86_64.tar.gz
-          echo "MUJOCO_LIB=$HOME/.mujoco/mujoco-3.3.2/lib" >> $GITHUB_ENV
+          echo "MUJOCO_DIR=$HOME/.mujoco/mujoco-3.3.2" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$HOME/.mujoco/mujoco-3.3.2/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
           
-      - name: check succeeds with MUJOCO_LIB
+      - name: check succeeds with MUJOCO_DIR
         run: |
           if cargo build; then
             echo 'cargo check succeeded with mujoco, as expected.'

--- a/README.md
+++ b/README.md
@@ -21,25 +21,27 @@
 
 ## Requirements
 
-- [MuJoCo 3.3.2](https://github.com/google-deepmind/mujoco/releases/tag/3.3.2) downloaded and expanded
-- `MUJOCO_LIB` environment variable containing the MuJoCo's **`lib` directory** path
+- [MuJoCo 3.3.2](https://github.com/google-deepmind/mujoco/releases/tag/3.3.2) downloaded
+  and expanded **as it is** (don't rename or partially move the files)
+- `MUJOCO_DIR` environment variable set to the path of the MuJoCo directory (e.g. `$HOME/.mujoco/mujoco-3.3.2`)
 
 ## Note & Tips
 
-- Generally, one way to setup is installing MuJoCo to _a default standard path_ like `/usr/local/lib/`
-  (or a folder in _PATH_ on Windows) and inserting to your shell config file:
+- One way to setup is to install MuJoCo to _a default standard path_ like `/usr/local/lib/`
+  (or a folder in _PATH_ on Windows), if needed create symlink to `mujoco-3.3.2/lib/libmujoco.so` there,
+  and insert to your shell config file:
   ```sh
   # example on Linux with /usr/local/lib/
-  export MUJOCO_LIB="/usr/local/lib/mujoco-3.3.2/lib"
+  export MUJOCO_DIR="/usr/local/lib/mujoco-3.3.2"
   ```
   Or if you'd like to avoid to install MuJoCo to such a system directory:
   ```sh
   # example on Linux with $HOME/.mujoco/
-  export MUJOCO_LIB="$HOME/.mujoco/mujoco-3.3.2/lib"
-  export LD_LIBRARY_PATH="$MUJOCO_LIB:$LD_LIBRARY_PATH"
+  export MUJOCO_DIR="$HOME/.mujoco/mujoco-3.3.2"
+  export LD_LIBRARY_PATH="$MUJOCO_DIR/lib:$LD_LIBRARY_PATH"
   ```
-- Depending on your setting, be sure to specify `MUJOCO_LIB` when executing your app.
-  (for example `LD_LIBRARY_PATH=$MUJOCO_LIB cargo run` on Linux)
+- Depending on your setting, be sure to specify `$MUJOCO_DIR/lib` as shared library path
+  when executing your app (for example `LD_LIBRARY_PATH=$MUJOCO_DIR/lib cargo run` on Linux)
 
 ## Usage
 

--- a/build.rs
+++ b/build.rs
@@ -46,15 +46,17 @@ fn main() {
         "`cargo fmt` is not available; This build script can't continue without it."
     );
 
-    let src_dir = Path::new(&env!("CARGO_MANIFEST_DIR")).join("src");
+    let src_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
     let bindgen_h = src_dir.join("bindgen.h").to_str().unwrap().to_owned();
     let bindgen_rs = src_dir.join("bindgen.rs").to_str().unwrap().to_owned();
 
     println!("cargo:rerun-if-changed={bindgen_h}");
 
-    let mujoco_lib = std::env::var("MUJOCO_LIB").expect("MUJOCO_LIB environment variable is not set");
-    let mujoco_include = Path::new(&mujoco_lib).parent().unwrap().join("include").to_str().unwrap().to_owned();
-    let mujoco_include_mujoco = Path::new(&mujoco_include).join("mujoco").to_str().unwrap().to_owned();
+    let mujoco_dir = std::env::var("MUJOCO_DIR").expect("MUJOCO_DIR environment variable is not set");
+    let mujoco_dir = Path::new(&mujoco_dir).canonicalize().expect("MUJOCO_DIR is not a valid path");
+    let mujoco_lib = mujoco_dir.join("lib").to_str().unwrap().to_owned();
+    let mujoco_include = mujoco_dir.join("include").to_str().unwrap().to_owned();
+    let mujoco_include_mujoco = mujoco_dir.join("include").join("mujoco").to_str().unwrap().to_owned();
 
     println!("cargo:rustc-link-search={mujoco_lib}");
     println!("cargo:rustc-link-lib=dylib=mujoco");


### PR DESCRIPTION
Documentation like "This crate requires `MUJOCO_LIB` environment variable set to ..." may be confusing: it can seem library ( `.so`, `.lib` ) path, but actually the path to a directory named `lib` ( `mujoco-a.b.c/lib` ) is required.

This PR will help users to understand what are required with less confusion.