### PR TITLE
docs: refer to previous works

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ See the [examples](./examples) directory for working examples.
 
 ## Previous Works
 
-- [ThButlah/mujoco-rs](https://github.com/TheButlah/mujoco-rs/)
+- [TheButlah/mujoco-rs](https://github.com/TheButlah/mujoco-rs)
   : archived by the owner on Sep 19, 2021.
 - [MuJoCo-Rust/MuJoCo-Rust](https://github.com/MuJoCo-Rust/MuJoCo-Rust)
   : seems not maintained anymore (last commit on 2 years ago) and not compatible with MuJoCo 3+.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ fn main() {
 
 See the [examples](./examples) directory for working examples.
 
+## Previous Works
+
+- [ThButlah/mujoco-rs](https://github.com/TheButlah/mujoco-rs/)
+  : archived by the owner on Sep 19, 2021.
+- [MuJoCo-Rust/MuJoCo-Rust](https://github.com/MuJoCo-Rust/MuJoCo-Rust)
+  : seems not maintained anymore (last commit on 2 years ago) and not compatible with MuJoCo 3+.
+
 ## License
 
 rusty_mujoco is licensed under [MIT LICENSE](https://github.com/rust-control/rusty_mujoco/blob/main/LICENSE).


### PR DESCRIPTION
Adds following section to README:

```md
## Previous Works

- [ThButlah/mujoco-rs](https://github.com/TheButlah/mujoco-rs)
  : archived by the owner on Sep 19, 2021.
- [MuJoCo-Rust/MuJoCo-Rust](https://github.com/MuJoCo-Rust/MuJoCo-Rust)
  : seems not maintained anymore (last commit on 2 years ago) and not compatible with MuJoCo 3+.
```