### PR TITLE
chore: bump version to 0.2 for breaking change in the naming convention

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "rusty_mujoco"
-version       = "0.1.0"
+version       = "0.2.0"
 edition       = "2024"
 authors       = ["kanarus <kanarus786@gmail.com>"]
 documentation = "https://docs.rs/rusty_mujoco"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 *Cargo.toml*
 ```toml
 [dependencies]
-rusty_mujoco = "0.1"
+rusty_mujoco = "0.2"
 ```
 
 *src/main.rs*


### PR DESCRIPTION
- ( breaking change in the naming convention: by #27 )